### PR TITLE
fetch 4 more posts instead of n+4 posts

### DIFF
--- a/src/firebase/firebaseModel.js
+++ b/src/firebase/firebaseModel.js
@@ -314,9 +314,13 @@ async function queryPostByUserUid(userUid) {
         console.error("Error getting documents: ", error);
     });
 }
-
-async function queryNewestPosts(amountOfPosts) {
-    const q = query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), limit(amountOfPosts));
+/**
+ * Return an array of n more posts after the last post in the array of posts returned by the previous call to this function.
+ * @param {Number} nMorePosts 
+ * @returns {Array} Array of posts in the form { id: String, user: Object, ...postData }
+ */
+async function queryMoreNewestPosts(nMorePosts) {
+    const q = queryMoreNewestPosts.lastVisiblePost ? query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(queryMoreNewestPosts.lastVisiblePost), limit(nMorePosts)) : query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), limit(nMorePosts));
     const querySnapshot = await getDocs(q);
     const posts = [];
     for (const doc of querySnapshot.docs) {
@@ -328,7 +332,8 @@ async function queryNewestPosts(amountOfPosts) {
             console.error("Error fetching user data:", error);
         }
     }
-    console.debug("queryNewestPosts: Current posts: ", posts);
+    queryMoreNewestPosts.lastVisiblePost = querySnapshot.docs[querySnapshot.docs.length-1];
+    console.debug("queryMoreNewestPosts: Current posts: ", posts);
     return posts; // return posts to caller
 }
 
@@ -390,4 +395,4 @@ async function queryFavoritePosts(amountOfPosts, uid) {
     return posts;
 }
 
-export { connectToFirestore, signInACB, signOutACB, readUserFromFirestore, readPostFromFirestore, savePostToFirestore, saveCommentToFireStore, likePostFirestore, dislikePostFirestore, followUserFirestore, unfollowUserFirestore, queryPostByUserUid, queryCommentsByPostId, queryNewestPosts, queryTopPosts, queryFavoritePosts, queryUsername };
+export { connectToFirestore, signInACB, signOutACB, readUserFromFirestore, readPostFromFirestore, savePostToFirestore, saveCommentToFireStore, likePostFirestore, dislikePostFirestore, followUserFirestore, unfollowUserFirestore, queryPostByUserUid, queryCommentsByPostId, queryMoreNewestPosts, queryTopPosts, queryFavoritePosts, queryUsername };

--- a/src/models/firePinsModel.js
+++ b/src/models/firePinsModel.js
@@ -1,6 +1,6 @@
 import { observable, reaction, action } from "mobx";
 import { v4 as uuidv4 } from 'uuid';
-import { savePostToFirestore, queryNewestPosts, queryTopPosts, queryFavoritePosts, likePostFirestore, dislikePostFirestore, followUserFirestore, unfollowUserFirestore, saveCommentToFireStore } from "../firebase/firebaseModel";
+import { savePostToFirestore, queryMoreNewestPosts, queryTopPosts, queryFavoritePosts, likePostFirestore, dislikePostFirestore, followUserFirestore, unfollowUserFirestore, saveCommentToFireStore } from "../firebase/firebaseModel";
 
 const model = observable({
   count: 1,
@@ -100,7 +100,7 @@ const model = observable({
   homePageData: {
     data: {
       topRatedPosts: [],
-      newestPosts: await queryNewestPosts(4),
+      newestPosts: await queryMoreNewestPosts(4),
     },
     setTopRatedPosts: action(function(posts) {
       console.debug("current homePageData.data.topRatedPosts: ", this.data.topRatedPosts);
@@ -121,8 +121,8 @@ const model = observable({
     },
     fetchNewestPosts: async function() {
       console.debug("this.data.newestPosts.length:", this.data.newestPosts.length);
-      const posts = await queryNewestPosts(this.data.newestPosts.length + 4);
-      this.setNewestPosts(posts);
+      const morePosts = await queryMoreNewestPosts(4);
+      this.setNewestPosts([...this.data.newestPosts, ...morePosts]);
     },
   },
   postDetailData: {


### PR DESCRIPTION
modified the behaviour of `fetchNewestPosts` to only fetch 4 more posts from Firestore instead of n+4 posts. 
This reduces the Firestore read quota usage as we have used 14k reads today.