### PR TITLE
Dev-NewestPostListenerManager

### DIFF
--- a/src/components/homepage/newPosts/NewPostsSection.jsx
+++ b/src/components/homepage/newPosts/NewPostsSection.jsx
@@ -46,7 +46,7 @@ export default function NewPostSection(props) {
         pageStart={0}
         loadMore={() => props.loadMorePosts()}
         hasMore={true /******************************** METHOD TO CHECK THIS ********************************/}
-        initialLoad={false}
+        initialLoad={true}
         loader={<div className="relative p-10" key={0}>
           <SuspenseAnimation loading={true} /></div>}
       >

--- a/src/firebase/NewestPostListenerManager.js
+++ b/src/firebase/NewestPostListenerManager.js
@@ -21,7 +21,7 @@ class NewestPostListenerManager {
     addNewestPostsListener() {
         console.debug('NewestPostListenerManager: addNewestPostsListener');
         const lastListenerDocs = this.listeners[this.listeners.length - 1]?.post;
-        const q = lastListenerDocs ? query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(lastListenerDocs.createdAt), limit(1)) : query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), limit(1));
+        const q = lastListenerDocs ? query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(lastListenerDocs.createdAt), limit(1)) : query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(new Date()), limit(1));
         const listener = {unsub: null, post: null};
         listener.unsub = onSnapshot(q, (querySnapshot) => {
             querySnapshot.docChanges().forEach(async (change) => {

--- a/src/firebase/NewestPostListenerManager.js
+++ b/src/firebase/NewestPostListenerManager.js
@@ -1,0 +1,43 @@
+import { onSnapshot } from "firebase/firestore";
+import { readUserFromFirestore } from "./firebaseModel";
+import { makeAutoObservable, autorun } from "mobx";
+
+class NewestPostListenerManager {
+    constructor(model) {
+        this.model = model;
+        this.listeners = [];
+        makeAutoObservable(this);
+        autorun(() => {
+            model.homePageData.setNewestPosts(this.listeners.map(l => l.post));
+        });
+    }
+    
+    addNewestPostsListener() {
+        const lastListenerDocs = this.listeners[this.listeners.length - 1]?.post;
+        const q = lastListenerDocs ? query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(lastListenerDocs.docRef), limit(1)) : query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), limit(1));
+        const listener = {unsub: null, post: null};
+        listener.unsub = onSnapshot(q, (querySnapshot) => {
+            querySnapshot.docChanges().forEach(async (change) => {
+                if (change.type === 'added') {
+                    const postData = change.doc.data();
+                    const user = await readUserFromFirestore(postData.createdBy);
+                    listener.post = { id: change.doc.id, user, ...postData };
+                    console.debug('NewestPostListenerManager: added', listener.post);
+                }
+                if (change.type === 'removed') {
+                    // Todo: remove listener from listeners
+                    console.debug('NewestPostListenerManager: removed');
+                    listener.unsub();
+                    this.removeListener(change.doc.id);
+                }
+            });
+        });
+        this.listeners.push(listener);
+    }
+    
+    removeListener(postId) {
+        this.listeners = this.listeners.filter(l => l !== listener);
+    }
+}
+
+export default NewestPostListenerManager;

--- a/src/firebase/NewestPostListenerManager.js
+++ b/src/firebase/NewestPostListenerManager.js
@@ -1,7 +1,7 @@
 import { collection, onSnapshot, query, orderBy, startAfter, endBefore, limit } from "firebase/firestore";
 import { db } from "./firebaseModel";
 import { readUserFromFirestore } from "./firebaseModel";
-import { makeAutoObservable, reaction, action, autorun } from "mobx";
+import { makeAutoObservable, reaction, action, when } from "mobx";
 
 class NewestPostListenerManager {
     constructor(model) {
@@ -17,6 +17,10 @@ class NewestPostListenerManager {
             model.homePageData.setNewestPostsBeforeTimeOfConstruction(postArr)
         });
         this.updateNewestPostsFromFirestoreListener(model);
+        when(()=>this.readyForAddingNewestPostsListener, ()=>this.addNewestPostsListener());
+        when(()=>this.readyForAddingNewestPostsListener, ()=>this.addNewestPostsListener());
+        when(()=>this.readyForAddingNewestPostsListener, ()=>this.addNewestPostsListener());
+        when(()=>this.readyForAddingNewestPostsListener, ()=>this.addNewestPostsListener());
     }
     
     setListeners = action((listeners) => this.listeners = listeners);

--- a/src/firebase/NewestPostListenerManager.js
+++ b/src/firebase/NewestPostListenerManager.js
@@ -17,10 +17,6 @@ class NewestPostListenerManager {
             model.homePageData.setNewestPostsBeforeTimeOfConstruction(postArr)
         });
         this.updateNewestPostsFromFirestoreListener(model);
-        when(()=>this.readyForAddingNewestPostsListener, ()=>this.addNewestPostsListener());
-        when(()=>this.readyForAddingNewestPostsListener, ()=>this.addNewestPostsListener());
-        when(()=>this.readyForAddingNewestPostsListener, ()=>this.addNewestPostsListener());
-        when(()=>this.readyForAddingNewestPostsListener, ()=>this.addNewestPostsListener());
     }
     
     setListeners = action((listeners) => this.listeners = listeners);

--- a/src/firebase/NewestPostListenerManager.js
+++ b/src/firebase/NewestPostListenerManager.js
@@ -15,9 +15,8 @@ class NewestPostListenerManager {
         });
     }
     
-    setListeners = action((listeners) =>
-        this.listeners = listeners
-    )
+    setListeners = action((listeners) => this.listeners = listeners);
+    setListenerPostAt = action((post, index) => this.listeners[index].post = post);
     
     addNewestPostsListener() {
         console.debug('NewestPostListenerManager: addNewestPostsListener');
@@ -33,6 +32,13 @@ class NewestPostListenerManager {
                     console.debug('NewestPostListenerManager: added', listener.post);
                     this.setListeners([...this.listeners, listener]);
                     console.debug('NewestPostListenerManager: this.listeners', this.listeners);
+                }
+                if (change.type === 'modified') {
+                    const postData = change.doc.data();
+                    const index = this.listeners.findIndex((listener)=>listener.post.id === change.doc.id);
+                    const updatedPost = { ...this.listeners[index].post, ...postData };
+                    this.setListenerPostAt(updatedPost, index);
+                    console.debug('NewestPostListenerManager: modified', updatedPost);
                 }
                 if (change.type === 'removed') {
                     // Todo: remove listener from listeners

--- a/src/firebase/NewestPostListenerManager.js
+++ b/src/firebase/NewestPostListenerManager.js
@@ -1,4 +1,4 @@
-import { collection, onSnapshot, query, orderBy, startAfter, limit } from "firebase/firestore";
+import { collection, onSnapshot, query, orderBy, startAfter, endBefore, limit } from "firebase/firestore";
 import { db } from "./firebaseModel";
 import { readUserFromFirestore } from "./firebaseModel";
 import { makeAutoObservable, reaction, action } from "mobx";
@@ -6,13 +6,16 @@ import { makeAutoObservable, reaction, action } from "mobx";
 class NewestPostListenerManager {
     constructor(model) {
         this.model = model;
+        this.newerThanConstructionPosts = [];
         this.listeners = [];
+        this.timeOfConstruction = new Date();
         makeAutoObservable(this);
         reaction(()=>this.listeners.map(l => l.post), ()=> {
             console.debug('NewestPostListenerManager: reaction', this.listeners);
             const postArr = this.listeners.map(l => l.post).filter(p => p!==null);
-            model.homePageData.setNewestPosts(postArr)
+            model.homePageData.setNewestPostsBeforeTimeOfConstruction(postArr)
         });
+        this.updateNewestPostsFromFirestoreListener(model);
     }
     
     setListeners = action((listeners) => this.listeners = listeners);
@@ -21,7 +24,7 @@ class NewestPostListenerManager {
     addNewestPostsListener() {
         console.debug('NewestPostListenerManager: addNewestPostsListener');
         const lastListenerDocs = this.listeners[this.listeners.length - 1]?.post;
-        const q = lastListenerDocs ? query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(lastListenerDocs.createdAt), limit(1)) : query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(new Date()), limit(1));
+        const q = lastListenerDocs ? query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(lastListenerDocs.createdAt), limit(1)) : query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(this.timeOfConstruction), limit(1));
         const listener = {unsub: null, post: null};
         listener.unsub = onSnapshot(q, (querySnapshot) => {
             querySnapshot.docChanges().forEach(async (change) => {
@@ -50,10 +53,25 @@ class NewestPostListenerManager {
         });
     }
     addFourNewestPostsListener() {
+        console.debug('NewestPostListenerManager: addFourNewestPostsListener');
         setTimeout(this.addNewestPostsListener.bind(this), 1000);
         setTimeout(this.addNewestPostsListener.bind(this), 2000);
     }
-    
+    updateNewestPostsFromFirestoreListener(model) {
+        const posts = collection(db, "Posts");
+        const q = query(posts, orderBy("createdAt", "desc"), endBefore(this.timeOfConstruction));
+        
+        const unsubscribe = onSnapshot(q, async (querySnapshot) => {
+            const postArr = [];
+            for (const doc of querySnapshot.docs) {
+                const postData = doc.data();
+                const user = await readUserFromFirestore(postData.createdBy);
+                const post = { id: doc.id, user, ...postData };
+                postArr.push(post);
+            }
+            model.newPostsData.setNewPostsData(postArr);
+        });
+    }
     removeListener(postId) {
         this.listeners = this.listeners.filter(l => l !== listener);
     }

--- a/src/firebase/NewestPostListenerManager.js
+++ b/src/firebase/NewestPostListenerManager.js
@@ -25,11 +25,12 @@ class NewestPostListenerManager {
     
     setListeners = action((listeners) => this.listeners = listeners);
     setListenerPostAt = action((post, index) => this.listeners[index].post = post);
+    setReadyForAddingNewestPostsListener = action((ready) => this.readyForAddingNewestPostsListener = ready);
     
     addNewestPostsListener() {
         if (!this.readyForAddingNewestPostsListener)
             return;
-        this.readyForAddingNewestPostsListener = false;
+        this.setReadyForAddingNewestPostsListener(false);
         console.debug('NewestPostListenerManager: addNewestPostsListener');
         const lastListenerDocs = this.listeners[this.listeners.length - 1]?.post;
         const q = lastListenerDocs ? query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(lastListenerDocs.createdAt), limit(1)) : query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(this.timeOfConstruction), limit(1));
@@ -45,7 +46,7 @@ class NewestPostListenerManager {
                     console.debug('NewestPostListenerManager: added', listener.post);
                     this.setListeners([...this.listeners, listener]);
                     console.debug('NewestPostListenerManager: this.listeners', this.listeners);
-                    this.readyForAddingNewestPostsListener = true;
+                    this.setReadyForAddingNewestPostsListener(true);
                 }
                 if (change.type === 'modified') {
                     const postData = change.doc.data();

--- a/src/firebase/firebaseModel.js
+++ b/src/firebase/firebaseModel.js
@@ -23,8 +23,7 @@ import {
     limit,
     startAfter,
     onSnapshot,
-    updateDoc,
-    endBefore
+    updateDoc
 } from "firebase/firestore";
 import { reaction } from "mobx";
 
@@ -108,10 +107,10 @@ function connectToFirestore(model) {
             model.user.setData({});
             unsubscribeOnSnapshotUser(); // Stop listening to the user document
         }
-    /*
+    }
     function updateNewestPostsFromFirestoreReaction(model) {
         const posts = collection(db, "Posts");
-        const q = query(posts, orderBy("createdAt", "desc"), endBefore());
+        const q = query(posts, orderBy("createdAt", "desc"), limit(1));
         function updateNewestPostsFromFirestoreCB(change) {
             if (change.type === "added") {
                 if (updateNewestPostsFromFirestoreCB.firstRun === undefined) { // First run, i.e. initial data from Firestore
@@ -129,16 +128,14 @@ function connectToFirestore(model) {
                         console.error("updateNewestPostsFromFirestoreReaction: Error fetching user data:", error);
                     });
             }
-            
         }
         const unsubscribe = onSnapshot(q, (querySnapshot) => {
             querySnapshot.docChanges().forEach(updateNewestPostsFromFirestoreCB);
         });
     }
-    */
     onAuthStateChanged(auth, onAuthStateChangedCB);
     reaction(watchUserCB, callSaveUserToFirestoreCB);
-    // updateNewestPostsFromFirestoreReaction(model);
+    updateNewestPostsFromFirestoreReaction(model);
 }
 
 function readUserFromFirestore(uid) {
@@ -404,43 +401,21 @@ async function queryPostByUserUid(userUid) {
  * @param {Number} nMorePosts 
  * @returns {Array} Array of posts in the form { id: String, user: Object, ...postData }
  */
-async function queryMoreNewestPosts(nMorePosts, startAfterCreatedAt) {
+async function queryMoreNewestPosts(nMorePosts) {
     const q = queryMoreNewestPosts.lastVisiblePost ? query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), startAfter(queryMoreNewestPosts.lastVisiblePost), limit(nMorePosts)) : query(collection(db, 'Posts'), orderBy('createdAt', 'desc'), limit(nMorePosts));
-    async function onSnapshotACB(querySnapshot) {
-        querySnapshot.docChanges().forEach((change) => {
-            if (change.type === "added") {
-                const postData = change.doc.data();
-                try {
-                    const user = readUserFromFirestore(postData.createdBy);
-                    posts.push({ id: change.doc.id, user: user, ...postData });
-                } catch (error) {
-                    console.error("Error fetching user data:", error);
-                }
-            }
-            if (change.type === "deleted") {
-                const postId = change.doc.id;
-                posts = posts.filter((post) => post.id !== postId);
-            }
-        });
-        posts = [];
-        for (const doc of querySnapshot.docs) {
-            const postData = doc.data();
-            try {
-                const user = await readUserFromFirestore(postData.createdBy);
-                posts.push({ id: doc.id, user: user, ...postData });
-            } catch (error) {
-                console.error("Error fetching user data:", error);
-            }
-        }
-        queryMoreNewestPosts.lastVisiblePost = querySnapshot.docs[querySnapshot.docs.length-1];
-        console.debug("queryMoreNewestPosts: Current posts: ", posts);
-        return posts; // return posts to caller
-    }
+    const querySnapshot = await getDocs(q);
     const posts = [];
-    const unsub = onSnapshot(q, onSnapshotACB);
+    for (const doc of querySnapshot.docs) {
+        const postData = doc.data();
+        try {
+            const user = await readUserFromFirestore(postData.createdBy);
+            posts.push({ id: doc.id, user: user, ...postData });
+        } catch (error) {
+            console.error("Error fetching user data:", error);
+        }
+    }
     queryMoreNewestPosts.lastVisiblePost = querySnapshot.docs[querySnapshot.docs.length-1];
     console.debug("queryMoreNewestPosts: Current posts: ", posts);
-    const listenerObj = { unsub: unsub, posts: posts};
     return posts; // return posts to caller
 }
 
@@ -502,4 +477,4 @@ async function queryFavoritePosts(amountOfPosts, uid) {
     return posts;
 }
 
-export { connectToFirestore, signInACB, signOutACB, readUserFromFirestore, postDataListener, removePostFromFirestore, savePostToFirestore, profileDataListener, saveCommentToFireStore, likePostFirestore, dislikePostFirestore, followUserFirestore, unfollowUserFirestore, queryPostByUserUid, postCommentsDataListener, queryMoreNewestPosts, queryTopPosts, queryFavoritePosts, queryUsername };
+export { db, connectToFirestore, signInACB, signOutACB, readUserFromFirestore, postDataListener, removePostFromFirestore, savePostToFirestore, profileDataListener, saveCommentToFireStore, likePostFirestore, dislikePostFirestore, followUserFirestore, unfollowUserFirestore, queryPostByUserUid, postCommentsDataListener, queryMoreNewestPosts, queryTopPosts, queryFavoritePosts, queryUsername };

--- a/src/firebase/firebaseModel.js
+++ b/src/firebase/firebaseModel.js
@@ -108,34 +108,8 @@ function connectToFirestore(model) {
             unsubscribeOnSnapshotUser(); // Stop listening to the user document
         }
     }
-    function updateNewestPostsFromFirestoreReaction(model) {
-        const posts = collection(db, "Posts");
-        const q = query(posts, orderBy("createdAt", "desc"), limit(1));
-        function updateNewestPostsFromFirestoreCB(change) {
-            if (change.type === "added") {
-                if (updateNewestPostsFromFirestoreCB.firstRun === undefined) { // First run, i.e. initial data from Firestore
-                    updateNewestPostsFromFirestoreCB.firstRun = true;
-                    console.debug("updateNewestPostsFromFirestoreReaction: Initial data from Firestore, not updating MobX store");
-                    return;
-                }
-                const postData = change.doc.data();
-                console.debug("updateNewestPostsFromFirestoreReaction: New post added to Firestore, updating MobX store\n change.doc.data(): ", postData);
-                readUserFromFirestore(postData.createdBy)
-                    .then((user) => {
-                        model.newPostsData.addNewPost({ id: change.doc.id, user: user, ...postData });
-                    })
-                    .catch((error) => {
-                        console.error("updateNewestPostsFromFirestoreReaction: Error fetching user data:", error);
-                    });
-            }
-        }
-        const unsubscribe = onSnapshot(q, (querySnapshot) => {
-            querySnapshot.docChanges().forEach(updateNewestPostsFromFirestoreCB);
-        });
-    }
     onAuthStateChanged(auth, onAuthStateChangedCB);
     reaction(watchUserCB, callSaveUserToFirestoreCB);
-    // updateNewestPostsFromFirestoreReaction(model);
 }
 
 function readUserFromFirestore(uid) {

--- a/src/firebase/firebaseModel.js
+++ b/src/firebase/firebaseModel.js
@@ -135,7 +135,7 @@ function connectToFirestore(model) {
     }
     onAuthStateChanged(auth, onAuthStateChangedCB);
     reaction(watchUserCB, callSaveUserToFirestoreCB);
-    updateNewestPostsFromFirestoreReaction(model);
+    // updateNewestPostsFromFirestoreReaction(model);
 }
 
 function readUserFromFirestore(uid) {

--- a/src/models/firePinsModel.js
+++ b/src/models/firePinsModel.js
@@ -113,6 +113,7 @@ const model = observable({
     data: {
       topRatedPosts: [],
       newestPosts: [],
+      newestPostsBeforeTimeOfConstruction: [],
     },
     setTopRatedPosts: action(function(posts) {
       console.debug("current homePageData.data.topRatedPosts: ", this.data.topRatedPosts);
@@ -125,6 +126,12 @@ const model = observable({
       console.debug("setting homePageData.data.newestPosts to: ", posts);
       this.data.newestPosts = posts;
       console.debug("new homePageData.data.newestPosts: ", this.data.newestPosts);
+    }),
+    setNewestPostsBeforeTimeOfConstruction: action(function(posts) {
+      console.debug("current homePageData.data.newestPostsBeforeTimeOfConstruction: ", this.data.newestPostsBeforeTimeOfConstruction);
+      console.debug("setting homePageData.data.newestPostsBeforeTimeOfConstruction to: ", posts);
+      this.data.newestPostsBeforeTimeOfConstruction = posts;
+      console.debug("new homePageData.data.newestPostsBeforeTimeOfConstruction: ", this.data.newestPostsBeforeTimeOfConstruction);
     }),
     fetchTopPosts: async function() {
       console.debug("this.data.topRatedPosts.length:", this.data.topRatedPosts.length);
@@ -289,7 +296,7 @@ const model = observable({
     addNewPost: action(function(post) {
       console.debug("adding new post: ", post);
       this.setNewPostsData([post, ...this.data]);
-      model.updateHomePageDataWithNewPosts();
+      // model.updateHomePageDataWithNewPosts();
     }),
   },
   /**

--- a/src/models/firePinsModel.js
+++ b/src/models/firePinsModel.js
@@ -2,6 +2,7 @@ import { observable, reaction, action, set } from "mobx";
 import { v4 as uuidv4 } from 'uuid';
 import { listOfGenre } from "../services/firePinsSource";
 import { savePostToFirestore, removePostFromFirestore, queryMoreNewestPosts, queryTopPosts, queryFavoritePosts, likePostFirestore, dislikePostFirestore, followUserFirestore, unfollowUserFirestore, saveCommentToFireStore } from "../firebase/firebaseModel";
+import NewestPostListenerManager from "../firebase/newestPostListenerManager";
 
 const model = observable({
   count: 1,
@@ -132,8 +133,7 @@ const model = observable({
     },
     fetchNewestPosts: async function() {
       console.debug("this.data.newestPosts.length:", this.data.newestPosts.length);
-      const morePosts = await queryMoreNewestPosts(4);
-      this.setNewestPosts([...this.data.newestPosts, ...morePosts]);
+      NewestPostListenerManager.addNewestPostsListener();
     },
   },
   postDetailData: {
@@ -321,6 +321,6 @@ const model = observable({
   uuid: uuidv4(),
 });
 
-
+const newestPostListenerManager = new NewestPostListenerManager(model);
 
 export default model;

--- a/src/models/firePinsModel.js
+++ b/src/models/firePinsModel.js
@@ -1,7 +1,7 @@
 import { observable, reaction, action, set } from "mobx";
 import { v4 as uuidv4 } from 'uuid';
 import { listOfGenre } from "../services/firePinsSource";
-import { savePostToFirestore, removePostFromFirestore, queryMoreNewestPosts, queryTopPosts, queryFavoritePosts, likePostFirestore, dislikePostFirestore, followUserFirestore, unfollowUserFirestore, saveCommentToFireStore } from "../firebase/firebaseModel";
+import { savePostToFirestore, removePostFromFirestore, queryTopPosts, queryFavoritePosts, likePostFirestore, dislikePostFirestore, followUserFirestore, unfollowUserFirestore, saveCommentToFireStore } from "../firebase/firebaseModel";
 import NewestPostListenerManager from "../firebase/newestPostListenerManager";
 
 const model = observable({
@@ -133,7 +133,7 @@ const model = observable({
     },
     fetchNewestPosts: async function() {
       console.debug("this.data.newestPosts.length:", this.data.newestPosts.length);
-      NewestPostListenerManager.addNewestPostsListener();
+      newestPostListenerManager.addFourNewestPostsListener();
     },
   },
   postDetailData: {

--- a/src/models/firePinsModel.js
+++ b/src/models/firePinsModel.js
@@ -140,7 +140,7 @@ const model = observable({
     },
     fetchNewestPosts: async function() {
       console.debug("this.data.newestPosts.length:", this.data.newestPosts.length);
-      newestPostListenerManager.addFourNewestPostsListener();
+      newestPostListenerManager.addNewestPostsListener();
     },
   },
   postDetailData: {

--- a/src/models/firePinsModel.js
+++ b/src/models/firePinsModel.js
@@ -301,7 +301,6 @@ const model = observable({
     addNewPost: action(function(post) {
       console.debug("adding new post: ", post);
       this.setNewPostsData([post, ...this.data]);
-      // model.updateHomePageDataWithNewPosts();
     }),
   },
   /**

--- a/src/models/firePinsModel.js
+++ b/src/models/firePinsModel.js
@@ -2,7 +2,7 @@ import { observable, reaction, action, set } from "mobx";
 import { v4 as uuidv4 } from 'uuid';
 import { listOfGenre } from "../services/firePinsSource";
 import { savePostToFirestore, removePostFromFirestore, queryTopPosts, queryFavoritePosts, likePostFirestore, dislikePostFirestore, followUserFirestore, unfollowUserFirestore, saveCommentToFireStore } from "../firebase/firebaseModel";
-import NewestPostListenerManager from "../firebase/newestPostListenerManager";
+import NewestPostListenerManager from "../firebase/NewestPostListenerManager";
 
 const model = observable({
   count: 1,

--- a/src/models/firePinsModel.js
+++ b/src/models/firePinsModel.js
@@ -140,7 +140,7 @@ const model = observable({
     }),
     fetchTopPosts: async function() {
       const posts = await queryTopPosts(12); // Hardcoded posts fetched once when app is initialised
-      this.setNewestPosts(posts);
+      this.setTopRatedPosts(posts);
     },
     fetchNewestPosts: async function() {
       console.debug("this.data.newestPosts.length:", this.data.newestPosts.length);

--- a/src/models/initialiseModel.js
+++ b/src/models/initialiseModel.js
@@ -74,12 +74,24 @@ function currentProfileUidReaction(model) {
     reaction(watchCurrentProfileUidCB, onCurrentProfileUidChangeCB);
 }
 
+function combineLatestPosts(model) {
+    function watchCB() {
+        return [model.homePageData.data.newestPostsBeforeTimeOfConstruction, model.newPostsData.data];
+    }
+    function updateNewestPostsCB() {
+        const newestPosts = [...model.newPostsData.data, ...model.homePageData.data.newestPostsBeforeTimeOfConstruction];
+        model.homePageData.setNewestPosts(newestPosts);
+    }
+    reaction(watchCB, updateNewestPostsCB);
+}
+
 export default async function initialiseModel(model) {
     console.debug("initialiseModel");
     connectToFirestore(model);
     settingsReaction(model);
     currentPostIdReaction(model);
     currentProfileUidReaction(model);
+    combineLatestPosts(model);
     model.homePageData.fetchNewestPosts();
     Object.assign(model, {listOfTMDBgenre: await listOfGenre()});
 }

--- a/src/models/initialiseModel.js
+++ b/src/models/initialiseModel.js
@@ -93,5 +93,8 @@ export default async function initialiseModel(model) {
     currentProfileUidReaction(model);
     combineLatestPosts(model);
     model.homePageData.fetchNewestPosts();
+    setTimeout(() => {
+        model.homePageData.fetchNewestPosts();
+    }, 1000);
     Object.assign(model, {listOfTMDBgenre: await listOfGenre()});
 }

--- a/src/models/initialiseModel.js
+++ b/src/models/initialiseModel.js
@@ -93,8 +93,8 @@ export default async function initialiseModel(model) {
     currentProfileUidReaction(model);
     combineLatestPosts(model);
     model.homePageData.fetchNewestPosts();
-    setTimeout(() => {
-        model.homePageData.fetchNewestPosts();
-    }, 1000);
+    setTimeout(() => model.homePageData.fetchNewestPosts(), 1500);
+    setTimeout(() => model.homePageData.fetchNewestPosts(), 3000);
+    setTimeout(() => model.homePageData.fetchNewestPosts(), 4500);
     Object.assign(model, {listOfTMDBgenre: await listOfGenre()});
 }

--- a/src/models/initialiseModel.js
+++ b/src/models/initialiseModel.js
@@ -90,9 +90,5 @@ export default async function initialiseModel(model) {
     currentPostIdReaction(model);
     currentProfileUidReaction(model);
     combineLatestPosts(model);
-    model.homePageData.fetchNewestPosts();
-    setTimeout(() => model.homePageData.fetchNewestPosts(), 1500);
-    setTimeout(() => model.homePageData.fetchNewestPosts(), 3000);
-    setTimeout(() => model.homePageData.fetchNewestPosts(), 4500);
     Object.assign(model, {listOfTMDBgenre: await listOfGenre()});
 }


### PR DESCRIPTION
- added NewestPostListenerManager
  - handles creation of snapshot listeners for newest posts
- use initialLoad from infinite scroll instead of hardcoding 4 posts
- migrated combine posts logic to combineLatestPosts in initialiseModel.js